### PR TITLE
Adição das Gravação do Grupo +1 e versionamento da aba Vídeos Gravados

### DIFF
--- a/docs/planejamento/checklistGrupo+1.md
+++ b/docs/planejamento/checklistGrupo+1.md
@@ -73,9 +73,15 @@ Segue o link referente ao repositório do grupo 10: https://github.com/Requisito
 - Introducing Rich Pictures - Rich Picture Drawing Guidelines. 4 p. Disponível em: https://aprender3.unb.br/pluginfile.php/3096055/mod_resource/content/2/1_5145791542719414573.pdf. Acessado em: 09 de abril de 2025
 
 
+## Gravação do Grupo +1 - Entreha 01
+
+### Grupo +1 Entrega 01  
+<iframe width="560" height="315" src="https://www.youtube.com/embed/JjRFmRJNH2E" frameborder="0" allowfullscreen></iframe>
+
 
 ## Histórico de Versões
 
 | Versão | Data       | Descrição            | Autor(es)                                                                                           | Revisor(es)                                      |
 | ------ | ---------- | -------------------- | --------------------------------------------------------------------------------------------------- | ------------------------------------------------ |
 | `1.0`  | 09/04/2025 | Criação do documento | [Lucas Alves](https://github.com/LucasAlves71) | Todos |
+| `1.1`  | 14/04/2025 | Adição da Gravação   | [Kaleb Macedo](https://github.com/kalebmacedo) | Todos

--- a/docs/videos/videos.md
+++ b/docs/videos/videos.md
@@ -26,3 +26,17 @@ Os vídeos estão armazenados como **não listados no YouTube** e podem ser disp
 
 ### Reunião 03 – Organização para apresentação e estruturação final  
 <iframe width="560" height="315" src="https://www.youtube.com/embed/j282D-g8U4M" frameborder="0" allowfullscreen></iframe>
+
+
+## Gravações Grupos +1
+
+### Entrega 01  
+<iframe width="560" height="315" src="https://www.youtube.com/embed/JjRFmRJNH2E" frameborder="0" allowfullscreen></iframe>
+
+
+## Histórico de Versões
+
+| Versão | Data | Descrição | Autor(es) | Revisor(es) |
+|--------|------|-----------|-----------|-------------|
+| 1.0 | 11/04/2024 | Criação da aba de Vídeos Gravados |  [Kaleb Macedo](https://github.com/kalebmacedo)  | Todos |
+| 1.1 | 14/04/2025 | Adição da Gravação do Grupo +1    |  [Kaleb Macedo](https://github.com/kalebmacedo)  | Todos |


### PR DESCRIPTION
# 📄 Pull Request: Adição das Gravações do Grupo +1 e Versionamento da Aba "Vídeos Gravados"

## Descrição

Este pull request realiza a atualização da documentação com as seguintes modificações principais:

- Inclusão da **gravação da reunião do Grupo +1**
- Atualização e **versionamento da aba "Vídeos Gravados"**
- Adição de **link clicável para visualização no YouTube**
- Reorganização da seção de vídeos para melhor navegação e rastreabilidade

## Arquivos Modificados

- `docs/videos.md`  
  - Adicionada a gravação da reunião adicional (Grupo +1)
  - Links clicáveis e estruturados para todas as reuniões gravadas
  - Padronização da seção com base nas reuniões anteriores

- `mkdocs.yml`  
  - Verificado o versionamento da aba de vídeos no menu lateral

## Objetivo

Organizar melhor o histórico de reuniões e garantir acesso facilitado às gravações, promovendo rastreabilidade, transparência e documentação adequada conforme critérios da disciplina.

## Checklist

- [x] Gravação do Grupo +1 adicionada com link funcional
- [x] Seção de vídeos reorganizada e atualizada
- [x] Navegação do MkDocs testada e validada
- [x] Commit versionado corretamente
